### PR TITLE
Bake Network app + add cert-manager, unpoller, and image hardening

### DIFF
--- a/.github/workflows/extract-linux-amd64.yaml
+++ b/.github/workflows/extract-linux-amd64.yaml
@@ -65,6 +65,54 @@ jobs:
           sudo chown -R runner:runner /home/runner/.local/share/containers/storage
           podman images
 
+      - name: Capture upstream OCI config + drift detection
+        # The application Dockerfile inherits Entrypoint/Cmd/Env/WorkingDir
+        # from this image via FROM. If Ubiquiti changes the entrypoint away
+        # from /sbin/init, our docker/entrypoint.sh's `exec /sbin/init` will
+        # silently break. Dump the upstream config to the workflow summary
+        # for auditability and fail loud on drift.
+        run: |
+          set -euo pipefail
+          PODMAN_IMAGE_ID=$(podman images uosserver --noheading | awk 'NR==1{print $3}')
+          if [ -z "$PODMAN_IMAGE_ID" ]; then
+            echo "uosserver image not found in podman storage" >&2
+            podman images
+            exit 1
+          fi
+          podman inspect "$PODMAN_IMAGE_ID" --format '{{json .Config}}' > /tmp/upstream-config.json
+
+          {
+            echo "## Upstream OCI image config (linux/amd64)"
+            echo ""
+            echo "\`\`\`json"
+            jq . /tmp/upstream-config.json
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          ENTRYPOINT=$(jq -c '.Entrypoint // []' /tmp/upstream-config.json)
+          CMD=$(jq -c '.Cmd // []' /tmp/upstream-config.json)
+          echo "Upstream Entrypoint: $ENTRYPOINT"
+          echo "Upstream Cmd:        $CMD"
+
+          # Accept either Entrypoint or Cmd ending in /sbin/init or init.
+          COMBINED=$(jq -r '((.Entrypoint // []) + (.Cmd // [])) | join(" ")' /tmp/upstream-config.json)
+          case "$COMBINED" in
+            *"/sbin/init"*|*" init"*|"init"|"/sbin/init")
+              echo "Upstream entrypoint matches expected systemd init invocation."
+              ;;
+            *)
+              echo "::error::Upstream entrypoint changed — expected /sbin/init, got: $COMBINED"
+              echo "::error::Update docker/entrypoint.sh and re-run."
+              exit 1
+              ;;
+          esac
+
+      - name: Upload upstream OCI config artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-config-linux-amd64
+          path: /tmp/upstream-config.json
+
       - name: Login to GHCR
         uses: redhat-actions/podman-login@v1
         with:

--- a/.github/workflows/extract-linux-arm64.yaml
+++ b/.github/workflows/extract-linux-arm64.yaml
@@ -61,6 +61,49 @@ jobs:
           sudo chown -R runner:runner /home/runner/.local/share/containers/storage
           podman images
 
+      - name: Capture upstream OCI config + drift detection
+        # See extract-linux-amd64.yaml for rationale.
+        run: |
+          set -euo pipefail
+          PODMAN_IMAGE_ID=$(podman images uosserver --noheading | awk 'NR==1{print $3}')
+          if [ -z "$PODMAN_IMAGE_ID" ]; then
+            echo "uosserver image not found in podman storage" >&2
+            podman images
+            exit 1
+          fi
+          podman inspect "$PODMAN_IMAGE_ID" --format '{{json .Config}}' > /tmp/upstream-config.json
+
+          {
+            echo "## Upstream OCI image config (linux/arm64)"
+            echo ""
+            echo "\`\`\`json"
+            jq . /tmp/upstream-config.json
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          ENTRYPOINT=$(jq -c '.Entrypoint // []' /tmp/upstream-config.json)
+          CMD=$(jq -c '.Cmd // []' /tmp/upstream-config.json)
+          echo "Upstream Entrypoint: $ENTRYPOINT"
+          echo "Upstream Cmd:        $CMD"
+
+          COMBINED=$(jq -r '((.Entrypoint // []) + (.Cmd // [])) | join(" ")' /tmp/upstream-config.json)
+          case "$COMBINED" in
+            *"/sbin/init"*|*" init"*|"init"|"/sbin/init")
+              echo "Upstream entrypoint matches expected systemd init invocation."
+              ;;
+            *)
+              echo "::error::Upstream entrypoint changed — expected /sbin/init, got: $COMBINED"
+              echo "::error::Update docker/entrypoint.sh and re-run."
+              exit 1
+              ;;
+          esac
+
+      - name: Upload upstream OCI config artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-config-linux-arm64
+          path: /tmp/upstream-config.json
+
       - name: Login to GHCR
         uses: redhat-actions/podman-login@v1
         with:

--- a/.github/workflows/network-app-release-check.yaml
+++ b/.github/workflows/network-app-release-check.yaml
@@ -1,0 +1,136 @@
+---
+name: Check for new UniFi Network application release
+
+# Polls Ubiquiti's Firmware Update Service (via the `uos` CLI in the pinned
+# uosserver base image) for the latest release-channel `unifi` package paired
+# with the current UOS_SERVER_VERSION. If newer than what's pinned in
+# docker/Dockerfile, opens a PR bumping NETWORK_APP_VERSION so the next image
+# build bakes it in.
+
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Open PR even if pinned version matches upstream"
+        required: false
+        default: "false"
+        type: string
+  schedule:
+    # 15 minutes after the UOS Server release-check so a same-morning UOS
+    # Server bump has a chance to settle first (the discovery container
+    # uses whatever UOSSERVER_TAG is currently on main).
+    - cron: "15 6 * * *"
+
+permissions:
+  contents: write
+  packages: read
+  pull-requests: write
+
+env:
+  REGISTRY: ghcr.io
+  UOSSERVER_IMAGE: ${{ github.repository_owner }}/uosserver
+
+jobs:
+  network-app-release-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read pinned versions from Dockerfile
+        id: pinned
+        run: |
+          UOSSERVER_TAG=$(awk -F= '/^ARG UOSSERVER_TAG=/ {print $2}' docker/Dockerfile)
+          NETWORK_APP_VERSION=$(awk -F= '/^ARG NETWORK_APP_VERSION=/ {print $2}' docker/Dockerfile)
+          if [ -z "$UOSSERVER_TAG" ] || [ -z "$NETWORK_APP_VERSION" ]; then
+            echo "Could not parse UOSSERVER_TAG or NETWORK_APP_VERSION from docker/Dockerfile" >&2
+            exit 1
+          fi
+          {
+            echo "uosserver_tag=$UOSSERVER_TAG"
+            echo "network_app_version=$NETWORK_APP_VERSION"
+          } | tee -a "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Discover latest Network app version paired with UOS Server
+        id: discover
+        env:
+          UOSSERVER_TAG: ${{ steps.pinned.outputs.uosserver_tag }}
+        run: |
+          # `uos runnable latest-versions unifi` queries Ubiquiti's FUS and
+          # returns the Network app release that's paired with this UOS
+          # Server version. Running it inside the uosserver base guarantees
+          # the same answer the live container would give.
+          IMAGE="${REGISTRY}/${UOSSERVER_IMAGE}:${UOSSERVER_TAG}"
+          docker pull --platform linux/amd64 "$IMAGE"
+          version=$(docker run --rm --platform linux/amd64 \
+            --entrypoint /usr/bin/uos "$IMAGE" \
+            runnable latest-versions unifi \
+            | jq -r '.release.version // empty')
+          if [ -z "$version" ]; then
+            echo "FUS returned no release for product=unifi on ${IMAGE}" >&2
+            exit 1
+          fi
+          echo "version=$version" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Compare against pinned version
+        id: compare
+        env:
+          FORCE: ${{ inputs.force }}
+          PINNED: ${{ steps.pinned.outputs.network_app_version }}
+          UPSTREAM: ${{ steps.discover.outputs.version }}
+        run: |
+          if [ "$FORCE" = "true" ]; then
+            echo "Force flag set, opening PR regardless of version match"
+            echo "should_pr=true" >> "$GITHUB_OUTPUT"
+          elif [ "$PINNED" = "$UPSTREAM" ]; then
+            echo "NETWORK_APP_VERSION ${PINNED} already pinned, nothing to do"
+            echo "should_pr=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New NETWORK_APP_VERSION ${UPSTREAM} detected (pinned: ${PINNED})"
+            echo "should_pr=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump Dockerfile
+        if: steps.compare.outputs.should_pr == 'true'
+        env:
+          UPSTREAM: ${{ steps.discover.outputs.version }}
+        run: |
+          sed -i "s|^ARG NETWORK_APP_VERSION=.*|ARG NETWORK_APP_VERSION=${UPSTREAM}|" docker/Dockerfile
+          # Patch-bump the chart so chart-releaser publishes a new release.
+          CHART_VERSION=$(awk '/^version:/ {print $2}' chart/Chart.yaml)
+          MAJOR=$(echo "$CHART_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$CHART_VERSION" | cut -d. -f2)
+          PATCH=$(echo "$CHART_VERSION" | cut -d. -f3)
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+          sed -i "s|^version: .*|version: ${NEW_VERSION}|" chart/Chart.yaml
+          echo "Chart bumped from ${CHART_VERSION} to ${NEW_VERSION}, NETWORK_APP_VERSION ${UPSTREAM}"
+
+      - name: Open pull request
+        if: steps.compare.outputs.should_pr == 'true'
+        uses: peter-evans/create-pull-request@v6
+        env:
+          UPSTREAM: ${{ steps.discover.outputs.version }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump Network application to ${{ env.UPSTREAM }}"
+          branch: bump/network-app-${{ env.UPSTREAM }}
+          base: main
+          title: "Bump Network application to ${{ env.UPSTREAM }}"
+          body: |
+            Automated bump:
+
+            * `NETWORK_APP_VERSION` → `${{ env.UPSTREAM }}`
+            * Chart `version` patch-bumped (chart-releaser will publish on merge)
+
+            Discovered via `uos runnable latest-versions unifi` against
+            `${{ env.REGISTRY }}/${{ env.UOSSERVER_IMAGE }}:${{ steps.pinned.outputs.uosserver_tag }}`.
+            FUS source: https://fw-update.ubnt.com (release channel).

--- a/README.md
+++ b/README.md
@@ -181,10 +181,29 @@ keeps managing its own internal cert for device-facing TLS.
 
 ## Prometheus metrics
 
-The chart ships an opt-in [unpoller](https://github.com/unpoller/unpoller)
-exporter (`unifiExporter.enabled: true`) that scrapes UOS and exposes metrics
-on `:9130`. See `chart/values.yaml` for auth options and the optional
-`ServiceMonitor`.
+Enable the bundled [unpoller](https://github.com/unpoller/unpoller) exporter to
+expose UOS metrics on `:9130`:
+
+```yaml
+unifiExporter:
+  enabled: true
+  config:
+    apiKey: "your-uos-api-key"     # generate at Settings → Admins & Users
+  serviceMonitor:
+    enabled: true                  # if you run the Prometheus Operator
+```
+
+Three auth modes:
+
+| Mode | Set | Notes |
+|------|-----|-------|
+| API key | `unifiExporter.config.apiKey` | Recommended on UOS 4+. |
+| Username + password | `unifiExporter.config.username` + `password` | Local **Viewer** admin. |
+| Pre-existing Secret | `unifiExporter.existingSecret.name` | Mount creds from ESO/Vault — chart reads `password` and/or `api-key` keys. |
+
+The exporter URL defaults to the in-cluster webui Service
+(`https://<release>-unifi-os-server-webui.<ns>.svc.cluster.local`); override
+with `unifiExporter.config.url` if you want it to scrape a different endpoint.
 
 ## Restoring a legacy controller `.unf` backup
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,36 @@ The chart wires all of this for you.
 
 Toggle each via `ports.<name>.enabled` in values.
 
+## TLS via cert-manager
+
+If you run cert-manager in your cluster, the chart can issue and rotate the
+ingress TLS certificate for you:
+
+```yaml
+ingress:
+  enabled: true
+  host: unifi.example.com
+
+certManager:
+  enabled: true
+  issuerRef:
+    name: letsencrypt-prod         # ClusterIssuer name
+    kind: ClusterIssuer
+  dnsNames:
+    - unifi.example.com
+```
+
+The chart creates a `Certificate` whose secret feeds the ingress automatically.
+This controls the secret in front of the ingress only — UniFi's bundled nginx
+keeps managing its own internal cert for device-facing TLS.
+
+## Prometheus metrics
+
+The chart ships an opt-in [unpoller](https://github.com/unpoller/unpoller)
+exporter (`unifiExporter.enabled: true`) that scrapes UOS and exposes metrics
+on `:9130`. See `chart/values.yaml` for auth options and the optional
+`ServiceMonitor`.
+
 ## Restoring a legacy controller `.unf` backup
 
 UOS's bundled Network app accepts `.unf` autobackups produced by older
@@ -273,6 +303,15 @@ kubectl rollout restart deploy/<release>
 
 Issues and PRs welcome. Please don't open issues for UOS bugs themselves —
 those should go to Ubiquiti.
+
+## Credits
+
+Several improvements in this repo (the discovery-shim approach for silencing
+`uos-discovery-client` polling, `Restart=no` drop-ins for the stub
+`uos-discovery-client` / `uos-agent` services, the bundled unpoller exporter,
+and a few other touches) were inspired by prior work in
+[ConnorsApps/unifi-os-helm](https://github.com/ConnorsApps/unifi-os-helm).
+Thanks to [@ConnorsApps](https://github.com/ConnorsApps) for the ideas.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,40 @@ self-hosted UniFi Network controllers (versions 5.x through 10.x).
 
 There's no need to manipulate Mongo dumps directly.
 
+### Re-adopting devices after a restore
+
+After restoring a backup, your devices may still hold an adoption key
+from the old controller and refuse to talk to UOS. They'll show up as
+disconnected in the device list. When that happens:
+
+1. **Factory-reset the device physically.** Hold the reset button until
+   the LED blinks the reset pattern. Software reset from the old
+   controller doesn't always clear the adoption state.
+2. **Remove the stale entry from UOS.** In the UI, click the device, open
+   its settings, and use the **Remove** button. This clears the old
+   adoption record so the device can be re-adopted fresh.
+3. **SSH to the device.** Default credentials are `ubnt` / `ubnt`:
+   ```
+   ssh ubnt@<device-ip>
+   ```
+4. **Point the device at UOS** with `set-inform`. The URL must be `http`
+   (not `https`), on port `8080`, with the `/inform` path:
+   ```
+   set-inform http://<uos-host>:8080/inform
+   ```
+   `<uos-host>` is the IP or hostname your devices can reach UOS on —
+   typically `systemIp` from your values.yaml, or the LoadBalancer IP of
+   the `communication` (8080) service.
+5. The device will show up under **Network → Devices** as **Pending
+   Adoption** within a few seconds. Click **Adopt**. UOS pushes config
+   and the device reboots.
+6. If the device doesn't appear within a minute, re-run `set-inform`
+   from the SSH session. Adoption sometimes drops the inform URL
+   mid-flight and a second nudge brings it back.
+
+Once adopted, UOS owns the inform URL and you won't need SSH again for
+that device.
+
 ## Autobackups
 
 UOS Network app autobackups land in `/var/lib/unifi/data/backup/autobackup/`
@@ -213,6 +247,27 @@ helm template unifi chart/ > /tmp/render.yaml
 4. Opens a PR bumping `UOSSERVER_TAG` and `UOS_SERVER_VERSION`.
 5. Merging the PR triggers `build-image.yaml`, which publishes a new
    `unifi-os-server` tag.
+
+## Network app updates
+
+The image bakes in the Network app at the version Ubiquiti ships with
+this UOS Server release. **Don't use the "Update" button in the UI.**
+
+Network app upgrades happen by image bump. We check Ubiquiti daily and
+publish a new [`unifi-os-server`](https://github.com/chrissnell/unifi-os-kubernetes/pkgs/container/unifi-os-server)
+image when a new Network app is released. Pull the new image and restart
+the pod.
+
+If you do click the in-UI updater, the new `.deb` lands on the data PVC
+and UOS replays it on every container start — so the upgrade sticks. The
+cost is that your Network app version no longer matches what's pinned in
+the image, and the next image bump won't downgrade you back. To roll back
+to the image's version after an in-UI update:
+
+```
+kubectl exec -n unifi <pod> -- rm /persistent/dpkg/bullseye/packages/unifi_*.deb
+kubectl rollout restart deploy/<release>
+```
 
 ## Contributing
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-os-server
 description: Self-hosted UniFi OS Server for Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "5.0.6"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/chrissnell/unifi-os-kubernetes

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-os-server
 description: Self-hosted UniFi OS Server for Kubernetes
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "5.0.6"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/chrissnell/unifi-os-kubernetes

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -64,3 +64,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-backups" (include "unifi-os-server.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+TLS secret name. Resolution order:
+  1. ingress.tls.secretName (explicit override)
+  2. certManager.secretName (explicit override when cert-manager is enabled)
+  3. <fullname>-tls (chart default; the Certificate template writes here)
+*/}}
+{{- define "unifi-os-server.tlsSecretName" -}}
+{{- if .Values.ingress.tls.secretName -}}
+{{- .Values.ingress.tls.secretName -}}
+{{- else if and .Values.certManager.enabled .Values.certManager.secretName -}}
+{{- .Values.certManager.secretName -}}
+{{- else -}}
+{{- printf "%s-tls" (include "unifi-os-server.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/certificate.yaml
+++ b/chart/templates/certificate.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "unifi-os-server.fullname" . }}-tls
+  labels:
+    {{- include "unifi-os-server.labels" . | nindent 4 }}
+  {{- with .Values.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "unifi-os-server.tlsSecretName" . | quote }}
+  {{- with .Values.certManager.duration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with .Values.certManager.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+  {{- with .Values.certManager.commonName }}
+  commonName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.certManager.dnsNames }}
+  dnsNames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.certManager.ipAddresses }}
+  ipAddresses:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.certManager.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.certManager.privateKey }}
+  privateKey:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.certManager.usages }}
+  usages:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  issuerRef:
+    {{- with .Values.certManager.issuerRef.kind }}
+    kind: {{ . }}
+    {{- end }}
+    {{- with .Values.certManager.issuerRef.group }}
+    group: {{ . }}
+    {{- end }}
+    name: {{ required "certManager.issuerRef.name is required when certManager.enabled is true" .Values.certManager.issuerRef.name }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -43,10 +43,6 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             {{- if .Values.systemIp }}
             - name: UOS_SYSTEM_IP
               value: {{ .Values.systemIp | quote }}
@@ -63,15 +59,6 @@ spec:
             - name: {{ $k }}
               value: {{ $v | quote }}
             {{- end }}
-          {{- if .Values.hostDockerInternal.enabled }}
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - /bin/bash
-                  - -c
-                  - 'echo "$HOST_IP host.docker.internal" >> /etc/hosts'
-          {{- end }}
           ports:
             {{- range $name, $p := .Values.ports }}
             {{- if $p.enabled }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         {{- include "unifi-os-server.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -17,8 +17,9 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.host | quote }}
-      {{- if .Values.ingress.tls.secretName }}
-      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- $secret := include "unifi-os-server.tlsSecretName" . }}
+      {{- if $secret }}
+      secretName: {{ $secret }}
       {{- end }}
   {{- end }}
   rules:

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -27,6 +27,7 @@ spec:
   {{- end }}
   selector:
     {{- $sel | nindent 4 }}
+    app.kubernetes.io/component: server
   ports:
     - name: {{ $name | lower | trunc 15 }}
       port: {{ $p.port }}

--- a/chart/templates/unifi-exporter.yaml
+++ b/chart/templates/unifi-exporter.yaml
@@ -116,15 +116,15 @@ spec:
             - name: UP_UNIFI_DEFAULT_HASH_PII
               value: {{ default false $cfg.hashPii | quote }}
             {{- if $useApiKey }}
-            # API key auth (UniFi OS 4+): unpoller treats UP_UNIFI_DEFAULT_PASS
-            # as the API key when UP_UNIFI_DEFAULT_USER is unset.
-            - name: UP_UNIFI_DEFAULT_PASS
+            # API-key auth (UniFi OS 4+): unpoller sends X-API-Key when
+            # UP_UNIFI_DEFAULT_API_KEY is set and skips user/pass login.
+            - name: UP_UNIFI_DEFAULT_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $secretName }}
                   key: {{ $apiKeyKey }}
             {{- else if .Values.unifiExporter.existingSecret.name }}
-              {{- /* user-provided secret: prefer api-key if present, else password */}}
+              {{- /* user-provided secret: prefer api-key path, else username+password */}}
               {{- if $cfg.username }}
             - name: UP_UNIFI_DEFAULT_USER
               value: {{ $cfg.username | quote }}
@@ -134,7 +134,7 @@ spec:
                   name: {{ $secretName }}
                   key: {{ $passwordKey }}
               {{- else }}
-            - name: UP_UNIFI_DEFAULT_PASS
+            - name: UP_UNIFI_DEFAULT_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $secretName }}

--- a/chart/templates/unifi-exporter.yaml
+++ b/chart/templates/unifi-exporter.yaml
@@ -1,0 +1,172 @@
+{{- if .Values.unifiExporter.enabled }}
+{{- $fullName := include "unifi-os-server.fullname" . -}}
+{{- $name := printf "%s-exporter" $fullName | trunc 63 | trimSuffix "-" -}}
+{{- $cfg := .Values.unifiExporter.config -}}
+{{- $svcName := printf "%s-webui" $fullName | trunc 63 | trimSuffix "-" -}}
+{{- $url := default (printf "https://%s.%s.svc.cluster.local" $svcName .Release.Namespace) $cfg.url -}}
+{{- $useApiKey := and (not .Values.unifiExporter.existingSecret.name) (ne (default "" $cfg.apiKey) "") -}}
+{{- $createSecret := and (not .Values.unifiExporter.existingSecret.name) (or (ne (default "" $cfg.password) "") (ne (default "" $cfg.apiKey) "")) -}}
+{{- $secretName := default (printf "%s-creds" $name) .Values.unifiExporter.existingSecret.name -}}
+{{- $passwordKey := default "password" .Values.unifiExporter.existingSecret.passwordKey -}}
+{{- $apiKeyKey := default "api-key" .Values.unifiExporter.existingSecret.apiKeyKey -}}
+{{- $componentLabels := dict "app.kubernetes.io/component" "unifi-exporter" -}}
+{{- if $createSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "unifi-os-server.labels" . | nindent 4 }}
+    {{- range $k, $v := $componentLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+type: Opaque
+stringData:
+  {{- if $cfg.password }}
+  {{ $passwordKey }}: {{ $cfg.password | quote }}
+  {{- end }}
+  {{- if $cfg.apiKey }}
+  {{ $apiKeyKey }}: {{ $cfg.apiKey | quote }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "unifi-os-server.labels" . | nindent 4 }}
+    {{- range $k, $v := $componentLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "unifi-os-server.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: unifi-exporter
+  ports:
+    - name: metrics
+      port: 9130
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "unifi-os-server.labels" . | nindent 4 }}
+    {{- range $k, $v := $componentLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "unifi-os-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: unifi-exporter
+  template:
+    metadata:
+      labels:
+        {{- include "unifi-os-server.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: unifi-exporter
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: unpoller
+          image: "{{ .Values.unifiExporter.image.repository }}:{{ .Values.unifiExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.unifiExporter.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 9130
+              protocol: TCP
+          env:
+            - name: UP_PROMETHEUS_HTTP_LISTEN
+              value: "0.0.0.0:9130"
+            - name: UP_PROMETHEUS_DISABLE
+              value: "false"
+            - name: UP_INFLUXDB_DISABLE
+              value: "true"
+            - name: UP_LOKI_DISABLE
+              value: "true"
+            - name: UP_UNIFI_DEFAULT_URL
+              value: {{ $url | quote }}
+            - name: UP_UNIFI_DEFAULT_VERIFY_SSL
+              value: {{ $cfg.verifyTLS | quote }}
+            - name: UP_UNIFI_DEFAULT_SAVE_SITES
+              value: {{ default true $cfg.saveSites | quote }}
+            - name: UP_UNIFI_DEFAULT_SAVE_DPI
+              value: {{ default false $cfg.saveDpi | quote }}
+            - name: UP_UNIFI_DEFAULT_SAVE_EVENTS
+              value: {{ default false $cfg.saveEvents | quote }}
+            - name: UP_UNIFI_DEFAULT_SAVE_ALARMS
+              value: {{ default false $cfg.saveAlarms | quote }}
+            - name: UP_UNIFI_DEFAULT_SAVE_ANOMALIES
+              value: {{ default false $cfg.saveAnomalies | quote }}
+            - name: UP_UNIFI_DEFAULT_SAVE_IDS
+              value: {{ default false $cfg.saveIds | quote }}
+            - name: UP_UNIFI_DEFAULT_HASH_PII
+              value: {{ default false $cfg.hashPii | quote }}
+            {{- if $useApiKey }}
+            # API key auth (UniFi OS 4+): unpoller treats UP_UNIFI_DEFAULT_PASS
+            # as the API key when UP_UNIFI_DEFAULT_USER is unset.
+            - name: UP_UNIFI_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $apiKeyKey }}
+            {{- else if .Values.unifiExporter.existingSecret.name }}
+              {{- /* user-provided secret: prefer api-key if present, else password */}}
+              {{- if $cfg.username }}
+            - name: UP_UNIFI_DEFAULT_USER
+              value: {{ $cfg.username | quote }}
+            - name: UP_UNIFI_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $passwordKey }}
+              {{- else }}
+            - name: UP_UNIFI_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $apiKeyKey }}
+              {{- end }}
+            {{- else if $cfg.password }}
+            - name: UP_UNIFI_DEFAULT_USER
+              value: {{ required "unifiExporter.config.username is required when using password auth" $cfg.username | quote }}
+            - name: UP_UNIFI_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $passwordKey }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.unifiExporter.resources | nindent 12 }}
+{{- if .Values.unifiExporter.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "unifi-os-server.labels" . | nindent 4 }}
+    {{- range $k, $v := $componentLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "unifi-os-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: unifi-exporter
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.unifiExporter.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.unifiExporter.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}
+{{- end }}

--- a/chart/templates/unifi-exporter.yaml
+++ b/chart/templates/unifi-exporter.yaml
@@ -71,6 +71,10 @@ spec:
       labels:
         {{- include "unifi-os-server.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: unifi-exporter
+      {{- with .Values.unifiExporter.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -273,6 +273,14 @@ unifiExporter:
     name: ""
     passwordKey: password
     apiKeyKey: api-key
+  # Annotations applied to the exporter pod. Use these for annotation-based
+  # Prometheus scrape discovery (the default kubernetes_sd_configs
+  # configuration in the prometheus-community chart). Leave empty if you
+  # use ServiceMonitor instead.
+  podAnnotations: {}
+  #  prometheus.io/scrape: "true"
+  #  prometheus.io/port: "9130"
+  #  prometheus.io/path: "/metrics"
   serviceMonitor:
     # Requires the Prometheus Operator CRDs.
     enabled: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -164,9 +164,42 @@ ingress:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
   tls:
     enabled: true
+    # Empty = derive name from cert-manager (if enabled) or default to
+    # "<release>-unifi-os-server-tls". Set explicitly to point the ingress
+    # at a Secret you manage out of band.
     secretName: ""
   path: /
   pathType: Prefix
+
+# Optional cert-manager Certificate for the ingress TLS secret. When enabled,
+# cert-manager issues and rotates a cert into <fullname>-tls (or
+# certManager.secretName if set), and the ingress template picks that secret
+# up automatically.
+#
+# Note: this controls the secret in front of the ingress, not the cert UOS's
+# bundled nginx serves to devices. UniFi rotates its internal cert itself.
+certManager:
+  enabled: false
+  # Override the generated Secret name. Leave empty for "<fullname>-tls".
+  secretName: ""
+  issuerRef:
+    name: ""              # required when enabled (e.g. "letsencrypt-prod")
+    kind: ClusterIssuer   # or "Issuer"
+    group: cert-manager.io
+  # Required: at least one of dnsNames or ipAddresses.
+  dnsNames: []
+  # - unifi.example.com
+  ipAddresses: []
+  commonName: ""
+  duration: ""             # e.g. "2160h"
+  renewBefore: ""          # e.g. "360h"
+  subject: {}
+  privateKey: {}
+  #  algorithm: ECDSA
+  #  size: 256
+  #  rotationPolicy: Always
+  usages: []
+  annotations: {}
 
 # Single-replica only — this is a stateful appliance.
 replicaCount: 1
@@ -199,7 +232,56 @@ probes:
 podAnnotations: {}
 podLabels: {}
 
-# Add the host IP as `host.docker.internal` in /etc/hosts (matches lemker
-# reference manifest behaviour; UOS uses this for some inter-service calls).
-hostDockerInternal:
-  enabled: true
+# Optional Prometheus exporter (unpoller) — runs as a separate Deployment that
+# scrapes UOS over HTTPS and exposes /metrics on port 9130. Three auth modes:
+#
+#   1. API key (recommended, UniFi OS 4+):
+#        unifiExporter.config.apiKey: "..."
+#      Generate at Settings → Admins & Users → (your user) → API Key.
+#
+#   2. Username + password (local Viewer admin):
+#        unifiExporter.config.username: "metrics"
+#        unifiExporter.config.password: "..."
+#
+#   3. Pre-existing Secret (mount whatever you keep in ESO/Vault):
+#        unifiExporter.existingSecret.name: my-secret
+#        unifiExporter.existingSecret.passwordKey: password
+#        unifiExporter.existingSecret.apiKeyKey:   api-key
+#      The api-key field, when non-empty, takes precedence over password.
+unifiExporter:
+  enabled: false
+  image:
+    repository: ghcr.io/unpoller/unpoller
+    tag: "v2.34.0"
+    pullPolicy: IfNotPresent
+  config:
+    # UniFi OS controller URL. Empty = derive from the chart's webui Service:
+    # https://<release>-unifi-os-server-webui.<namespace>.svc.cluster.local
+    url: ""
+    username: ""
+    password: ""
+    apiKey: ""
+    verifyTLS: false
+    saveSites: true
+    saveDpi: false
+    saveEvents: false
+    saveAlarms: false
+    saveAnomalies: false
+    saveIds: false
+    hashPii: false
+  existingSecret:
+    name: ""
+    passwordKey: password
+    apiKeyKey: api-key
+  serviceMonitor:
+    # Requires the Prometheus Operator CRDs.
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,11 +52,23 @@ RUN set -eux; \
 # - SKIP_DPKG_CACHE=yes suppresses the ubnt-dpkg-cache post-invoke hook
 #   so we don't bake a /persistent/dpkg cache into the image (it would
 #   be shadowed by the data PVC at runtime anyway).
+# - The dpkg.cfg.d hook config wraps the Ubiquiti pre/post-invoke
+#   scripts in `systemd-cat -t TAG …`. systemd-cat fails without a
+#   running journald, which makes dpkg abort with
+#     "Failed to create stream fd: No such file or directory"
+#   uos catches that as IO error and the bake aborts. Strip the
+#   wrapper so the underlying scripts run directly during build, then
+#   restore the original config so journald-driven logging works at
+#   runtime.
 RUN set -eux; \
     printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d; \
     chmod +x /usr/sbin/policy-rc.d; \
+    HOOK=/etc/dpkg/dpkg.cfg.d/015-ubnt-dpkg-status; \
+    cp "$HOOK" "$HOOK.original"; \
+    sed -i 's|/usr/bin/systemd-cat -t [a-z-]* ||g' "$HOOK"; \
     SKIP_DPKG_CACHE=yes \
       /usr/bin/uos runnable install --version "${NETWORK_APP_VERSION}" unifi; \
+    mv "$HOOK.original" "$HOOK"; \
     rm /usr/sbin/policy-rc.d; \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,30 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 ENV UOS_SERVER_VERSION="5.0.6"
 
+# Network application version. Bumped automatically by the
+# network-app-release-check workflow whenever Ubiquiti's FUS publishes a
+# newer release-channel `unifi` paired with this UOS_SERVER_VERSION.
+ARG NETWORK_APP_VERSION=10.3.55-34128-1
+ENV NETWORK_APP_VERSION=${NETWORK_APP_VERSION}
+
+# Bake the Network app into the image so first boot doesn't show the
+# "Install Network App" prompt. Uses Ubiquiti's own `uos` CLI so the
+# package, signing, and dependency resolution match exactly what UOS
+# would do at runtime.
+#
+# - policy-rc.d short-circuits service-start attempts in postinst;
+#   systemd isn't running during `docker build`.
+# - SKIP_DPKG_CACHE=yes suppresses the ubnt-dpkg-cache post-invoke hook
+#   so we don't bake a /persistent/dpkg cache into the image (it would
+#   be shadowed by the data PVC at runtime anyway).
+RUN set -eux; \
+    printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d; \
+    chmod +x /usr/sbin/policy-rc.d; \
+    SKIP_DPKG_CACHE=yes \
+      /usr/bin/uos runnable install --version "${NETWORK_APP_VERSION}" unifi; \
+    rm /usr/sbin/policy-rc.d; \
+    rm -rf /var/lib/apt/lists/*
+
 # systemd inside the container expects SIGRTMIN+3 to perform a clean shutdown.
 STOPSIGNAL SIGRTMIN+3
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,11 +27,10 @@ ENV UOS_SERVER_VERSION="5.0.6"
 ARG NETWORK_APP_VERSION=10.3.55-34128-1
 ENV NETWORK_APP_VERSION=${NETWORK_APP_VERSION}
 
-# `uos runnable install` reads /usr/lib/version (firmware version file).
-# Ubiquiti's installer writes that file on the host, not inside the image —
-# entrypoint.sh recreates it at runtime, but we also need it at build time
-# for the bake step below. Match the entrypoint's format. Same for
-# /usr/lib/platform if it's missing in upstream.
+# `uos runnable install` reads /usr/lib/version (firmware version file)
+# and writes to /persistent/dpkg (its package cache). At runtime systemd
+# and the PVC mounts populate these paths; at build time they're absent.
+# Recreate the minimum set so the bake step below succeeds.
 RUN set -eux; \
     echo "UOSSERVER.0000000.${UOS_SERVER_VERSION}.0000000.000000.0000" > /usr/lib/version; \
     if [ ! -s /usr/lib/platform ]; then \
@@ -40,7 +39,8 @@ RUN set -eux; \
             arm64) echo arm64 > /usr/lib/platform ;; \
             *)     echo "linux-$(dpkg --print-architecture)" > /usr/lib/platform ;; \
         esac; \
-    fi
+    fi; \
+    mkdir -p /persistent/dpkg /persistent/.config /data /srv /var/lib/unifi
 
 # Bake the Network app into the image so first boot doesn't show the
 # "Install Network App" prompt. Uses Ubiquiti's own `uos` CLI so the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,12 +63,17 @@ RUN set -eux; \
 RUN set -eux; \
     printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d; \
     chmod +x /usr/sbin/policy-rc.d; \
-    HOOK=/etc/dpkg/dpkg.cfg.d/015-ubnt-dpkg-status; \
-    cp "$HOOK" "$HOOK.original"; \
-    sed -i 's|/usr/bin/systemd-cat -t [a-z-]* ||g' "$HOOK"; \
+    for HOOK in /etc/dpkg/dpkg.cfg.d/015-ubnt-dpkg-status \
+                /etc/dpkg/dpkg.cfg.d/020-ubnt-dpkg-cache; do \
+      cp "$HOOK" "$HOOK.original"; \
+      sed -i 's|/usr/bin/systemd-cat -t [a-z-]* ||g' "$HOOK"; \
+    done; \
     SKIP_DPKG_CACHE=yes \
       /usr/bin/uos runnable install --version "${NETWORK_APP_VERSION}" unifi; \
-    mv "$HOOK.original" "$HOOK"; \
+    for HOOK in /etc/dpkg/dpkg.cfg.d/015-ubnt-dpkg-status \
+                /etc/dpkg/dpkg.cfg.d/020-ubnt-dpkg-cache; do \
+      mv "$HOOK.original" "$HOOK"; \
+    done; \
     rm /usr/sbin/policy-rc.d; \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,21 @@ ENV UOS_SERVER_VERSION="5.0.6"
 ARG NETWORK_APP_VERSION=10.3.55-34128-1
 ENV NETWORK_APP_VERSION=${NETWORK_APP_VERSION}
 
+# `uos runnable install` reads /usr/lib/version (firmware version file).
+# Ubiquiti's installer writes that file on the host, not inside the image —
+# entrypoint.sh recreates it at runtime, but we also need it at build time
+# for the bake step below. Match the entrypoint's format. Same for
+# /usr/lib/platform if it's missing in upstream.
+RUN set -eux; \
+    echo "UOSSERVER.0000000.${UOS_SERVER_VERSION}.0000000.000000.0000" > /usr/lib/version; \
+    if [ ! -s /usr/lib/platform ]; then \
+        case "$(dpkg --print-architecture)" in \
+            amd64) echo linux-x64 > /usr/lib/platform ;; \
+            arm64) echo arm64 > /usr/lib/platform ;; \
+            *)     echo "linux-$(dpkg --print-architecture)" > /usr/lib/platform ;; \
+        esac; \
+    fi
+
 # Bake the Network app into the image so first boot doesn't show the
 # "Install Network App" prompt. Uses Ubiquiti's own `uos` CLI so the
 # package, signing, and dependency resolution match exactly what UOS

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,34 @@ RUN set -eux; \
     rm /usr/sbin/policy-rc.d; \
     rm -rf /var/lib/apt/lists/*
 
+# Point unifi-core's discovery client at localhost. Upstream defaults to
+# host.docker.internal, which doesn't resolve inside a Kubernetes pod and
+# previously required a postStart `/etc/hosts` hack in the chart.
+RUN if [ -f /etc/default/unifi-core_advanced ]; then \
+      sed -i 's|host\.docker\.internal|localhost|g' /etc/default/unifi-core_advanced; \
+    fi
+
+# uos-discovery-client and uos-agent ship as stub binaries — they exit
+# immediately ("Stub package") with no real functionality. Both units use
+# Restart=always + StartLimitIntervalSec=0, so the stubs restart-storm and
+# fill the journal with noise. Drop-in overrides suppress the loop.
+RUN mkdir -p \
+        /etc/systemd/system/uos-discovery-client.service.d \
+        /etc/systemd/system/uos-agent.service.d \
+    && printf '[Service]\nRestart=no\n' \
+        > /etc/systemd/system/uos-discovery-client.service.d/no-restart.conf \
+    && printf '[Service]\nRestart=no\n' \
+        > /etc/systemd/system/uos-agent.service.d/no-restart.conf
+
+# Discovery shim — minimal Node HTTP server on 127.0.0.1:11002 that
+# satisfies unifi-core's discovery polls so it stops logging
+# "ECONNREFUSED 127.0.0.1:11002" / "Failed to fetch network interfaces"
+# every few seconds. See discovery-shim.js for protocol details.
+COPY discovery-shim.js /usr/local/lib/uos-discovery-shim/shim.js
+COPY uos-discovery-shim.service /etc/systemd/system/uos-discovery-shim.service
+RUN ln -sf /etc/systemd/system/uos-discovery-shim.service \
+        /etc/systemd/system/multi-user.target.wants/uos-discovery-shim.service
+
 # systemd inside the container expects SIGRTMIN+3 to perform a clean shutdown.
 STOPSIGNAL SIGRTMIN+3
 

--- a/docker/discovery-shim.js
+++ b/docker/discovery-shim.js
@@ -1,0 +1,54 @@
+// uos-discovery-client ships as a stub binary that exits immediately, so
+// nothing ever listens on port 11002 (the discoveryClientUrl that
+// unifi-core polls). Without a listener, unifi-core logs two recurring
+// warnings every few seconds:
+//
+//   [system] Failed to fetch network interfaces from discovery agent
+//   [discovery.client] Error on client scan: ECONNREFUSED 127.0.0.1:11002
+//
+// This shim is a minimal HTTP server that satisfies those calls so the
+// log spam stops and unifi-core gets a chance to resolve its lanIp:
+//
+//   GET /scan        → []                    (no UDP broadcast in a pod)
+//   GET <anything>   → os.networkInterfaces() (matches unifi-core's
+//                                              ZodRecord schema)
+//   HEAD /healthz    → 200
+//
+// Runs under systemd as uos-discovery-shim.service. Uses only Node
+// standard library — Node is already in the image (unifi-core is Node).
+
+const http = require("http");
+const os = require("os");
+
+const PORT = Number(process.env.DISCOVERY_SHIM_PORT || 11002);
+const HOST = process.env.DISCOVERY_SHIM_HOST || "127.0.0.1";
+
+function writeJson(res, statusCode, body) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(body));
+}
+
+const server = http.createServer((req, res) => {
+  const method = req.method || "GET";
+  const url = req.url || "/";
+
+  if (method === "HEAD" && (url === "/" || url === "/healthz")) {
+    res.statusCode = 200;
+    return res.end();
+  }
+
+  if (url.startsWith("/scan")) {
+    return writeJson(res, 200, []);
+  }
+
+  if (method === "GET") {
+    return writeJson(res, 200, os.networkInterfaces());
+  }
+
+  return writeJson(res, 404, {});
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`uos-discovery-shim listening on ${HOST}:${PORT}`);
+});

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -94,7 +94,35 @@ Type=simple
 EOF
 fi
 
-# 7. Optional: pin system_ip in unifi network properties.
+# 7. Redirect Go-service logs to stdout so `kubectl logs` / docker logs see them.
+# These services read their settings from /data/<svc>/ws/config.props and default
+# to logging into per-service files inside the container, which are invisible to
+# standard log aggregation. We append the log-redirect properties idempotently:
+# if the file already has `log.std=true` we leave it alone, so user customizations
+# survive container restarts.
+ensure_log_redirect() {
+    local cfg="$1"
+    local dir
+    dir="$(dirname "$cfg")"
+    mkdir -p "$dir"
+    if [ -f "$cfg" ] && grep -qE '^[[:space:]]*log\.std[[:space:]]*=[[:space:]]*true' "$cfg"; then
+        return 0
+    fi
+    {
+        echo ""
+        echo "# Added by uos-entrypoint: redirect logs to stdout for container log aggregation"
+        echo "log.std = true"
+        echo "log.redirect_std_output = false"
+        echo "log.std_to_file.enable = false"
+    } >> "$cfg"
+}
+
+for svc in ulp-go ucs-agent unifi-directory uid-agent unifi-credential-server \
+           ucs-user-assets unifi-identity-update; do
+    ensure_log_redirect "$DATA_DIR/$svc/ws/config.props"
+done
+
+# 8. Optional: pin system_ip in unifi network properties.
 UNIFI_SYSTEM_PROPERTIES="/var/lib/unifi/system.properties"
 if [ -n "${UOS_SYSTEM_IP:-}" ]; then
     echo "Setting system_ip=$UOS_SYSTEM_IP in $UNIFI_SYSTEM_PROPERTIES"

--- a/docker/uos-discovery-shim.service
+++ b/docker/uos-discovery-shim.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=UniFi OS discovery-client shim (replaces stub uos-discovery-client)
+After=network.target
+Before=unifi-core.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/node /usr/local/lib/uos-discovery-shim/shim.js
+Restart=on-failure
+RestartSec=2s
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

This branch grew well past its original scope. It now ships:

### Image (docker/)
- **Bake the Network app at build time** via `uos runnable install` so first boot doesn't show the "Install Network App" prompt.
- **Discovery shim** — minimal Node HTTP server on `127.0.0.1:11002` (systemd-managed) so `unifi-core` stops logging `ECONNREFUSED 127.0.0.1:11002` / "Failed to fetch network interfaces" every few seconds. The stub `uos-discovery-client` never serves that port.
- **Restart=no drop-ins** for `uos-discovery-client.service` and `uos-agent.service` to suppress the stub-binary restart-storm.
- **Patch `host.docker.internal` → `localhost`** in `unifi-core_advanced` at build time. Drops the matching chart-side `postStart` `/etc/hosts` hack.
- **Go-service log redirection** — `entrypoint.sh` idempotently sets `log.std=true` etc. in `/data/<svc>/ws/config.props` for the seven Go services so their logs land in stdout / `kubectl logs`.
- **`uos runnable install` build-time fixes** — write `/usr/lib/version` and `/usr/lib/platform` before the bake, pre-create `/persistent` + `/data` + `/srv` + `/var/lib/unifi`, and bypass the `systemd-cat` wrapper in both `dpkg.cfg.d/015-ubnt-dpkg-status` and `020-ubnt-dpkg-cache` so dpkg hooks don't fail without journald.

### Chart (chart/)
- **cert-manager `Certificate` template** wired into the ingress secret via a `tlsSecretName` helper.
- **unpoller Prometheus exporter** — Deployment + Service + optional ServiceMonitor, supports api-key, password, or existing-Secret auth; configurable pod annotations for annotation-based scrape discovery (plain prometheus, not just operator).
- **Component-label disambiguation** — adds `app.kubernetes.io/component=server` to the UOS pod and to every Service selector so the `unifi-webui` Service stops accidentally matching the exporter pod.

### CI (.github/workflows/)
- **Drift detection in extract workflows** — capture upstream OCI `Config` to step summary + artifact, fail loudly if the entrypoint diverges from `/sbin/init`.

### Misc
- README sections for cert-manager, Prometheus metrics, and a CREDITS section attributing several ideas to ConnorsApps/unifi-os-helm.

## Test plan

- [x] CI `build-image.yaml` builds amd64 + arm64 (`bake-network-app` tag).
- [x] Helm chart lint + render in default and full configurations.
- [x] Live cluster: chart upgrade with `unifiExporter.enabled=true`, dashboards under Infrastructure folder, exporter authed via API key, Prometheus target health=up.
- [ ] Live cluster: image upgrade to `bake-network-app` tag (out of scope for this PR — chart is on `latest`).
