### PR TITLE
fix(ci): link podman to /usr/bin so the UOS installer finds it

### DIFF
--- a/.github/workflows/extract-linux-amd64.yaml
+++ b/.github/workflows/extract-linux-amd64.yaml
@@ -44,6 +44,22 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h /
 
+      - name: Ensure the installer can find podman
+        run: |
+          set -euo pipefail
+          if [ -x /usr/bin/podman ]; then
+            echo "/usr/bin/podman already present"
+          else
+            podman_path=$(command -v podman || true)
+            if [ -z "$podman_path" ]; then
+              echo "::error::podman is not installed on this runner" >&2
+              exit 1
+            fi
+            echo "Linking $podman_path to /usr/bin/podman"
+            sudo ln -sf "$podman_path" /usr/bin/podman
+          fi
+          /usr/bin/podman --version
+
       - name: Run UniFi OS Server installer
         run: |
           mkdir -p /home/runner/.config/containers
@@ -54,6 +70,10 @@ jobs:
           sudo chmod +x unifi-os-server
           # Installer prompts y/N to start service post-install; we don't care.
           echo "y" | sudo ./unifi-os-server || true
+          if ! sudo test -d /home/uosserver/.local/share/containers/storage/overlay; then
+            echo "::error::Installer left no podman image at /home/uosserver/.local/share/containers/storage — see the installer output above." >&2
+            exit 1
+          fi
 
       - name: Move uosserver image into runner podman storage
         run: |

--- a/.github/workflows/extract-linux-arm64.yaml
+++ b/.github/workflows/extract-linux-arm64.yaml
@@ -41,6 +41,22 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h /
 
+      - name: Ensure the installer can find podman
+        run: |
+          set -euo pipefail
+          if [ -x /usr/bin/podman ]; then
+            echo "/usr/bin/podman already present"
+          else
+            podman_path=$(command -v podman || true)
+            if [ -z "$podman_path" ]; then
+              echo "::error::podman is not installed on this runner" >&2
+              exit 1
+            fi
+            echo "Linking $podman_path to /usr/bin/podman"
+            sudo ln -sf "$podman_path" /usr/bin/podman
+          fi
+          /usr/bin/podman --version
+
       - name: Run UniFi OS Server installer
         run: |
           mkdir -p /home/runner/.config/containers
@@ -50,6 +66,10 @@ jobs:
           curl -fsSL -o unifi-os-server "${{ inputs.UOS_DOWNLOAD }}"
           sudo chmod +x unifi-os-server
           echo "y" | sudo ./unifi-os-server || true
+          if ! sudo test -d /home/uosserver/.local/share/containers/storage/overlay; then
+            echo "::error::Installer left no podman image at /home/uosserver/.local/share/containers/storage — see the installer output above." >&2
+            exit 1
+          fi
 
       - name: Move uosserver image into runner podman storage
         run: |


### PR DESCRIPTION
Ubiquiti's installer probes the literal path /usr/bin/podman rather than resolving it on PATH. The runner image moved podman to /usr/local/bin when it swapped the apt package for a static bundle (actions/runner-images#14412), so both extract jobs abort with:

> ERROR Failed to install UniFi OS Server err=Missing container runtime /usr/bin/podman

The extract jobs only run when there is a new UOS release, so this went unnoticed until 5.1.37 on 2026-08-21 and has failed every day since.

The installer step ends in `|| true`, so it reported success and the failure surfaced one step later as `cp: cannot stat` on a storage directory that was never created. Assert the installer actually produced an image, so the next breakage names itself.