### PR TITLE
fix(entrypoint): write /usr/lib/app_model and product_name for UOS 5.…

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,9 +23,11 @@ if [ ! -f "$DATA_DIR/uos_uuid" ]; then
     fi
 fi
 
-# 2. Write the UOS version string the bundled services expect.
+# 2. Write the UOS identity files the bundled services expect.
 echo "Setting UOS_SERVER_VERSION=${UOS_SERVER_VERSION}"
 echo "UOSSERVER.0000000.${UOS_SERVER_VERSION}.0000000.000000.0000" > /usr/lib/version
+echo "UOSSERVER" > /usr/lib/app_model
+echo "UniFi OS Server" > /usr/lib/product_name
 
 # 3. Map dpkg arch to UOS firmware platform.
 ARCH="$(dpkg --print-architecture)"


### PR DESCRIPTION
…1.37

UniFi OS Server 5.1.37 reads the console model from /usr/lib/app_model via /sbin/ubnt-tools (APP_MODEL=$(cat /usr/lib/app_model), used as the boardSysIds lookup key). The entrypoint only wrote /usr/lib/version and /usr/lib/platform, so the model resolved to "" and unifi-core crash-looped on boot with:

    crash uncaughtException: Unsupported console model: ""

nginx then never binds port 80, all HTTP probes fail, and the container is restarted forever.

ubnt-tools also unconditionally reads /usr/lib/product_name (non-fatal, but errors on every invocation), so write that as well. Values match the official UOS installer: model UOSSERVER (sysid 0xae01, same prefix already used in the /usr/lib/version string), product name "UniFi OS Server".

Fixes #18.

Validated using our unifi-os k8s deployment.