### PR TITLE
ci(build-image): serialize builds to fix mutable-tag race

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -14,6 +14,15 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Serialize builds per ref so the mutable tags (latest, main, the version
+# tags) always land in commit order. Without this, concurrent pushes race
+# and `latest` can settle on whichever job finishes last rather than the
+# newest commit. cancel-in-progress stays false so every commit still
+# publishes its immutable `sha-<commit>` image for GitOps pinning.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/unifi-os-server

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -14,13 +14,19 @@ on:
     types: [published]
   workflow_dispatch:
 
-# Serialize builds per ref so the mutable tags (latest, main, the version
-# tags) always land in commit order. Without this, concurrent pushes race
-# and `latest` can settle on whichever job finishes last rather than the
-# newest commit. cancel-in-progress stays false so every commit still
-# publishes its immutable `sha-<commit>` image for GitOps pinning.
+# Serialize this publish workflow so its mutable tags (latest, main, and the
+# version tags) never race. Without a concurrency group, simultaneous runs
+# push the same tags in parallel and `latest` can settle on whichever job
+# finishes last rather than the newest commit. Grouping by workflow (not ref)
+# also serializes release events against main pushes, which write those same
+# shared tags. cancel-in-progress stays false so an in-progress build always
+# runs to completion and publishes its immutable `sha-<commit>` image rather
+# than being killed mid-publish. Caveat: GitHub keeps only the newest *pending*
+# run per group, so a burst of pushes within one build window can supersede an
+# intermediate commit's queued run before it starts — that commit then gets no
+# sha image. Acceptable here, since only completed/announced shas are pinned.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Problem

Near-simultaneous pushes to `main` run `build-image.yaml` in parallel. The mutable tags (`latest`, `main`, version tags) are applied by whichever job finishes **last**, not the newest commit — so `latest` can settle on an older commit purely on CI timing.

## Fix

Add a workflow-scoped `concurrency` group so runs of this publish workflow serialize. Grouping by `github.workflow` (rather than ref) also serializes `release` events against `main` pushes, which write the same shared mutable tags.

`cancel-in-progress: false` so an in-progress build runs to completion and publishes its immutable `sha-<commit>` image instead of being killed mid-publish.

**Known caveat (documented inline):** GitHub keeps only the newest *pending* run per group, so a rapid burst of pushes within one build window can supersede an intermediate commit's queued run before it starts — that commit gets no `sha-` image. Acceptable, since only completed/announced shas are pinned. `latest` always converges to the newest commit either way.

Reviewed; an initial version of the comment overstated the sha guarantee and was corrected.
