### PR TITLE
Pin released chart to immutable image digest

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 40
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -64,47 +64,59 @@ jobs:
           REPO="${REGISTRY}/${IMAGE}"
           APPVER=$(awk -F'"' '/^appVersion:/ {print $2}' chart/Chart.yaml)
           SHORT_SHA="${SHA:0:7}"
-
-          # Did this push touch the image sources? If so, build-image.yaml is
-          # (re)building the app image for this commit, and we must pin THAT
-          # build — addressed by its immutable sha-<commit> tag once it lands.
-          # Otherwise the image is unchanged and the current appVersion tag
-          # already resolves to the right content. Default to "changed" when we
-          # can't tell, so we never pin a tag that's still mid-rebuild.
-          IMAGE_CHANGED=1
-          if [ -n "${BEFORE}" ] \
-             && [ "${BEFORE}" != "0000000000000000000000000000000000000000" ]; then
-            if git diff --name-only "${BEFORE}" "${SHA}" \
-                 -- docker/ .github/workflows/build-image.yaml | grep -q .; then
-              IMAGE_CHANGED=1
-            else
-              IMAGE_CHANGED=0
-            fi
-          fi
+          SHA_REF="${REPO}:sha-${SHORT_SHA}"
 
           resolve() {
             docker buildx imagetools inspect "$1" \
               --format '{{ .Manifest.Digest }}' 2>/dev/null
           }
 
+          # Is build-image.yaml (re)building the app image for THIS commit? It
+          # runs on the same push whenever docker/ or its own workflow changes.
+          # On a push we can tell from the diff; on workflow_dispatch (no BEFORE)
+          # or a force-push that rewrote BEFORE we can't, so we treat it as
+          # changed and require the exact per-commit image rather than trusting
+          # a mutable tag that might still be mid-rebuild.
+          IMAGE_CHANGED=1
+          if [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+            # workflow_dispatch: no prior ref. The image (if any) is already
+            # built; don't hard-wait — probe the per-commit tag, else appVersion.
+            IMAGE_CHANGED=0
+          elif [ -n "${BEFORE}" ]; then
+            if CHANGED="$(git diff --name-only "${BEFORE}" "${SHA}" \
+                 -- docker/ .github/workflows/build-image.yaml 2>/dev/null)"; then
+              [ -n "${CHANGED}" ] || IMAGE_CHANGED=0
+            fi
+            # git diff failed (BEFORE unreachable): leave IMAGE_CHANGED=1.
+          fi
+
           REF=""
           if [ "${IMAGE_CHANGED}" = "1" ]; then
-            echo "Image sources changed; waiting for ${REPO}:sha-${SHORT_SHA}"
-            DEADLINE=$(( $(date +%s) + 1500 ))   # up to 25 min for multi-arch
-            while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
-              if resolve "${REPO}:sha-${SHORT_SHA}" >/dev/null; then
-                REF="${REPO}:sha-${SHORT_SHA}"
-                break
+            # The image is being rebuilt for this commit. Wait for its immutable
+            # per-commit tag and pin exactly that. Never fall back to the mutable
+            # appVersion tag here: a network-app bump changes the image without
+            # bumping appVersion, so that tag can still resolve to the previous
+            # build — pinning it would recreate the stale-image trap this fixes.
+            echo "Image sources changed; waiting for ${SHA_REF}"
+            DEADLINE=$(( $(date +%s) + 1800 ))   # ~30 min; build-image caps at 30
+            until resolve "${SHA_REF}" >/dev/null; do
+              if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
+                echo "Timed out waiting for ${SHA_REF}; refusing to pin a mutable tag" >&2
+                exit 1
               fi
               echo "  not published yet, retrying in 20s..."
               sleep 20
             done
-            if [ -z "${REF}" ]; then
-              echo "::warning::sha-${SHORT_SHA} never appeared; falling back to :${APPVER}"
+            REF="${SHA_REF}"
+          else
+            # Image unchanged for this release (chart-only push or manual
+            # dispatch). Prefer the exact per-commit image if it exists, else the
+            # current appVersion tag, which already points at stable content.
+            if resolve "${SHA_REF}" >/dev/null; then
+              REF="${SHA_REF}"
+            else
+              REF="${REPO}:${APPVER}"
             fi
-          fi
-          if [ -z "${REF}" ]; then
-            REF="${REPO}:${APPVER}"
           fi
 
           echo "Resolving digest from ${REF}"

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -2,6 +2,15 @@
 name: Release Helm chart
 
 # Packages the chart and publishes via chart-releaser to a `gh-pages` branch.
+#
+# Before packaging, the released chart is pinned to the immutable content
+# digest of the app image it was cut with (image.digest), so every published
+# chart version maps 1:1 to exactly one image build. This is what guarantees a
+# `helm upgrade` always rolls the pod and re-pulls the right image even under
+# the default pullPolicy: IfNotPresent — the image ref changes whenever the
+# content changes, so a stale cached tag can never shadow a fixed build. The
+# in-repo values.yaml keeps image.digest empty (floating tag) for local/dev;
+# the digest is only stamped into the packaged artifact here.
 
 on:
   push:
@@ -10,14 +19,21 @@ on:
       - 'chart/Chart.yaml'
   workflow_dispatch:
 
+# Serialize releases so a manual dispatch can't race a push and publish a
+# half-stamped chart. skip_existing then makes whichever wins idempotent.
+concurrency:
+  group: chart-release
+  cancel-in-progress: false
+
 permissions:
   contents: write
+  packages: read
   pages: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 35
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,6 +44,85 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image digest to pin
+        id: digest
+        env:
+          REGISTRY: ghcr.io
+          IMAGE: ${{ github.repository_owner }}/unifi-os-server
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          REPO="${REGISTRY}/${IMAGE}"
+          APPVER=$(awk -F'"' '/^appVersion:/ {print $2}' chart/Chart.yaml)
+          SHORT_SHA="${SHA:0:7}"
+
+          # Did this push touch the image sources? If so, build-image.yaml is
+          # (re)building the app image for this commit, and we must pin THAT
+          # build — addressed by its immutable sha-<commit> tag once it lands.
+          # Otherwise the image is unchanged and the current appVersion tag
+          # already resolves to the right content. Default to "changed" when we
+          # can't tell, so we never pin a tag that's still mid-rebuild.
+          IMAGE_CHANGED=1
+          if [ -n "${BEFORE}" ] \
+             && [ "${BEFORE}" != "0000000000000000000000000000000000000000" ]; then
+            if git diff --name-only "${BEFORE}" "${SHA}" \
+                 -- docker/ .github/workflows/build-image.yaml | grep -q .; then
+              IMAGE_CHANGED=1
+            else
+              IMAGE_CHANGED=0
+            fi
+          fi
+
+          resolve() {
+            docker buildx imagetools inspect "$1" \
+              --format '{{ .Manifest.Digest }}' 2>/dev/null
+          }
+
+          REF=""
+          if [ "${IMAGE_CHANGED}" = "1" ]; then
+            echo "Image sources changed; waiting for ${REPO}:sha-${SHORT_SHA}"
+            DEADLINE=$(( $(date +%s) + 1500 ))   # up to 25 min for multi-arch
+            while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+              if resolve "${REPO}:sha-${SHORT_SHA}" >/dev/null; then
+                REF="${REPO}:sha-${SHORT_SHA}"
+                break
+              fi
+              echo "  not published yet, retrying in 20s..."
+              sleep 20
+            done
+            if [ -z "${REF}" ]; then
+              echo "::warning::sha-${SHORT_SHA} never appeared; falling back to :${APPVER}"
+            fi
+          fi
+          if [ -z "${REF}" ]; then
+            REF="${REPO}:${APPVER}"
+          fi
+
+          echo "Resolving digest from ${REF}"
+          DIGEST="$(resolve "${REF}")"
+          if [ -z "${DIGEST}" ]; then
+            echo "Could not resolve a digest from ${REF}" >&2
+            exit 1
+          fi
+          echo "Pinning image digest ${DIGEST}"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp digest into chart values
+        env:
+          DIGEST: ${{ steps.digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          sed -i "s|^  digest: .*|  digest: \"${DIGEST}\"|" chart/values.yaml
+          grep -n '^  digest:' chart/values.yaml
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/README.md
+++ b/README.md
@@ -296,6 +296,17 @@ helm template unifi chart/ > /tmp/render.yaml
 4. Opens a PR bumping `UOSSERVER_TAG` and `UOS_SERVER_VERSION`.
 5. Merging the PR triggers `build-image.yaml`, which publishes a new
    `unifi-os-server` tag.
+6. `chart-release.yaml` then pins the released chart to that image's
+   immutable content digest (`image.digest`) before publishing, so every
+   chart version maps 1:1 to one image build.
+
+Because released charts reference the image by digest, a `helm upgrade`
+always changes the pod's image ref and rolls it — even with the default
+`pullPolicy: IfNotPresent`. This closes the trap where two chart versions
+shared a mutable `appVersion` tag (e.g. `0.2.8` and `0.2.9` both pinned
+`5.1.37`) and a node's cached image was never replaced on upgrade. The
+in-repo `values.yaml` leaves `image.digest` empty so local/dev checkouts
+still float on the `appVersion` tag.
 
 ## Network app updates
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-os-server
 description: Self-hosted UniFi OS Server for Kubernetes
 type: application
-version: 0.2.10
+version: 0.2.11
 appVersion: "5.1.40"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/chrissnell/unifi-os-kubernetes

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -36,8 +36,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "unifi-os-server.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/* Returns the data PVC name (handles existingClaim). */}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,6 +7,14 @@ image:
   repository: ghcr.io/chrissnell/unifi-os-server
   # If unset, Chart.appVersion is used.
   tag: ""
+  # Immutable content digest (sha256:...). When set it takes precedence over
+  # `tag` and pins the exact image published alongside this chart release.
+  # Released charts ship with this stamped by CI (see chart-release.yaml), so
+  # every chart version maps 1:1 to one image build. This is what makes an
+  # upgrade always roll the pod even under pullPolicy: IfNotPresent — the ref
+  # changes whenever the image content changes, so a stale cached tag can never
+  # shadow a fixed build. Left empty in-repo for local/dev checkouts.
+  digest: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Problem

The chart resolves its image tag from `Chart.appVersion` (the UOS version), and `build-image.yaml` publishes that as a **mutable** tag. Any chart release that changed the image *without* changing the UOS version reused the same tag over different content — `0.2.8` and `0.2.9` both pinned `unifi-os-server:5.1.37`.

With the default `pullPolicy: IfNotPresent`, a node that cached the broken `0.2.8` build never re-pulled the fixed one on `helm upgrade` to `0.2.9` (the upgrade doesn't even change the pod spec, since the image string is identical). That's the root cause of the "stuck not-ready on chart ≥ 0.2.8" reports in #23 persisting across `0.2.9`.

## Fix

Pin each *released* chart to the immutable content digest of the image it was cut with, so every chart version maps 1:1 to one image build.

- **`chart/templates/_helpers.tpl`** — `unifi-os-server.image` renders `repo@<digest>` when `image.digest` is set, else falls back to the `appVersion`/`tag` behavior unchanged.
- **`chart/values.yaml`** — adds `image.digest`, left empty in-repo so local/dev checkouts still float on the tag.
- **`.github/workflows/chart-release.yaml`** — before packaging, resolves the digest of the image built for the release commit (the immutable `sha-<commit>` tag when `docker/**` changed, waiting for `build-image.yaml` to finish; otherwise the current `appVersion` tag) and stamps it into the packaged chart. The in-repo source stays on the floating tag; only the published artifact carries the digest.
- **`chart/Chart.yaml`** — patch-bump to `0.2.11` so merging this exercises the mechanism and ships the first digest-pinned release.

## Effect

A `helm upgrade` between any two chart releases now always changes the pod's image ref and rolls it — even under `IfNotPresent` — because the digest changes whenever the image content changes. A stale cached tag can no longer shadow a fixed build. No change to the daily UOS / network-app detection PRs; they already patch-bump the chart version on every image-affecting change.

## Verification

- `helm lint chart` passes.
- `helm template` renders `repo:5.1.40` with no digest, `repo@sha256:…` when `image.digest` is set, and digest takes precedence over `tag`.
- CI `sed` stamp verified against the real `values.yaml` line (single match).
- `chart-release.yaml` parses as valid YAML.
