### PR TITLE
fix(chart): mount backups PVC at the app's real autobackup path

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-os-server
 description: Self-hosted UniFi OS Server for Kubernetes
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "5.1.42"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/chrissnell/unifi-os-kubernetes

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
             {{- end }}
             {{- if .Values.persistence.backups.enabled }}
             - name: backups
-              mountPath: /var/lib/unifi/data/backup
+              mountPath: /var/lib/unifi/backup
             {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -95,7 +95,7 @@ persistence:
     #  path: /volume1/NFS/unifi-os/mongo
 
   # Optional dedicated PVC for the Network app's autobackup directory
-  # (/var/lib/unifi/data/backup). When enabled, this overlays the main data
+  # (/var/lib/unifi/backup). When enabled, this overlays the main data
   # PVC so autobackups land on storage you can snapshot / replicate / scrub
   # independently. Leave disabled to keep autobackups inside the data PVC.
   backups:


### PR DESCRIPTION
## Summary

- Move the dedicated backups PVC mount from `/var/lib/unifi/data/backup` (a dead end) to `/var/lib/unifi/backup` (where the Network app actually writes autobackups)
- Update the `values.yaml` comment to reflect the correct path
- Bump chart to `0.2.13`

## Why

The UniFi Network app writes autobackups to `/usr/lib/unifi/data/backup`. Inside the container, `/usr/lib/unifi/data` is a symlink to `/var/lib/unifi`, so the true on-disk path is `/var/lib/unifi/backup`. The chart was mounting the backups PVC one directory over at `/var/lib/unifi/data/backup`, which is a real but unused directory. Net effect: `persistence.backups.enabled: true` did nothing — autobackups accumulated on the main data PVC and the backups PVC stayed empty. The "snapshot / replicate / scrub independently" promise in `values.yaml` was silently broken.

## Upgrade note

If you were running with `backups.enabled: true` and have existing autobackups on the data PVC, copy them out to the backups PVC location before upgrading, otherwise the new mount will hide them:

```bash
kubectl -n <ns> exec <pod> -- sh -c \
  'cp -a /var/lib/unifi/backup/. /var/lib/unifi/data/backup/'
# then helm upgrade
```

After upgrade, `/var/lib/unifi/backup` will be backed by the backups PVC and autobackups will land there directly.

## Test plan
- [x] `helm lint chart/`
- [x] `helm template chart/ --set persistence.backups.enabled=true --set persistence.backups.existingClaim=x` — confirmed rendered `mountPath: /var/lib/unifi/backup`
- [ ] Deploy `0.2.13` and confirm next monthly autobackup lands on the backups PVC