### PR TITLE
Add `labels` config option for `service` and `ports` blocks

### DIFF
--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -3,6 +3,8 @@
 {{- $labels := include "unifi-os-server.labels" . -}}
 {{- $svc := .Values.service -}}
 {{- range $name, $p := .Values.ports }}
+{{- $mergedLabels := merge (default (dict) $p.labels) (default (dict) $svc.labels) }}
+{{- $mergedAnnotations := merge (default (dict) $p.annotations) (default (dict) $svc.annotations) }}
 {{- if $p.enabled }}
 ---
 apiVersion: v1
@@ -11,11 +13,13 @@ metadata:
   name: {{ printf "%s-%s" $fullName ($name | kebabcase) | trunc 63 | trimSuffix "-" }}
   labels:
     {{- $labels | nindent 4 }}
+    {{- if $mergedLabels }}
+    {{- toYaml $mergedLabels | nindent 4 }}
+    {{- end }}
     unifi-os-server.io/port: {{ $name | quote }}
-  {{- $merged := merge (default (dict) $p.annotations) (default (dict) $svc.annotations) }}
-  {{- if $merged }}
+  {{- if $mergedAnnotations }}
   annotations:
-    {{- toYaml $merged | nindent 4 }}
+    {{- toYaml $mergedAnnotations | nindent 4 }}
   {{- end }}
 spec:
   type: {{ $svc.type }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -132,6 +132,8 @@ service:
   # When type is LoadBalancer, this IP is requested. Empty = let the cluster
   # decide.
   loadBalancerIP: ""
+  # Labels applied to all created services.
+  labels: {}
   # Annotations applied to all created services.
   annotations: {}
   # External traffic policy for LoadBalancer/NodePort services.
@@ -143,9 +145,10 @@ service:
   externalTrafficPolicy: Cluster
 
 ports:
-  # Each entry may set `annotations: { ... }` to add per-service annotations
-  # (merged on top of `service.annotations` above). Useful for example to set
-  # external-mdns hostnames on just the webui service.
+  # Each entry may set `annotations: { ... }` and `labels: { ... }` to add
+  # per-service metadata (merged on top of `service.annotations` and 
+  # `service.labels` above). Useful for example to set external-mdns hostnames
+  # on just the webui service.
   webui:            { enabled: true,  port: 443,   targetPort: 443,   protocol: TCP, description: "Web UI / API" }
   communication:    { enabled: true,  port: 8080,  targetPort: 8080,  protocol: TCP, description: "Device communication / inform" }
   stun:             { enabled: true,  port: 3478,  targetPort: 3478,  protocol: UDP, description: "STUN" }


### PR DESCRIPTION
Fixes #29.

Testing:
- [X] `helm lint chart/` passes
- [X] `helm template chart --set 'service.labels.foo=foo-lbl' --set 'ports.webui.labels.foo=bar-lbl' --set 'ports.communication.labels.baz=baz-lbl'` sets labels as expected, with `ports` labels overriding `service` labels

